### PR TITLE
Favicon pathing

### DIFF
--- a/views/partials/core_head.ejs
+++ b/views/partials/core_head.ejs
@@ -6,5 +6,5 @@
 <% } %>
 <link rel="icon" 
       type="image/png" 
-      href="icons/NewFrog.png">
+      href="/Icons/NewFrog.png">
 <!-- TODO: analytics -->


### PR DESCRIPTION
Favicon was referenced relatively instead of statically, see previous branch 'favicon'
https://github.com/ToyDragon/frogtown2020/commit/e162ac9a446b3095f88448db3f2172e34c282315 