### PR TITLE
Jenkins v3

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,82 @@
+def body = ''
+def comment
+pipeline {
+    agent any
+
+    stages {
+        stage('PR Check') {
+            steps {
+                script {
+                  // CHANGE_ID is set only for pull requests, so it is safe to access the pullRequest global variable
+                  if (env.CHANGE_ID) {
+                      echo 'Building with PR.'
+                      body='Build started. [Details](http://kismarton.frogtown.me:8079/job/PullRequestBuilds/view/change-requests/job/PR-' + env.CHANGE_ID + '/)'
+                      comment=pullRequest.comment(body)
+                  } else {
+                      echo 'Aborting, can\'t build without a PR.'
+                      currentBuild.result = 'ABORTED'
+                      error('Building without PR.')
+                  }
+                }
+            }
+        }
+        stage('Build') {
+            steps {
+                sh 'npm install && npm run-script build && ./docker_build.sh jenkins local'
+            }
+        }
+        stage('Test') {
+            steps {
+                sh 'npm test'
+            }
+        }
+        stage('Deploy') {
+            steps {
+                script {
+                    body += '\nCleaning up old container.'
+                    pullRequest.editComment(comment.id, body)
+                }
+                sh '''
+                  PORT=$(expr 8543 + ${BUILD_ID} % 5);
+                  echo Using port $PORT;
+                  CONTAINERID=$(docker ps -q --filter publish=$PORT);
+                  echo Found existing container: $CONTAINERID;
+                  [ -z "$CONTAINERID" ] || docker stop $(docker ps -q --filter publish=$PORT);
+                  docker run -d -l jenkins -p $PORT:8443 gcr.io/frogtown/frogtown2020/local:jenkins;
+                '''
+                script {
+                    body += '\nDeployed [test server](https://kismarton.frogtown.me:' + (8543 + ((env.BUILD_ID as Integer) % 5)) + ') for change ' + env.CHANGE_ID + '/' + env.BUILD_ID
+                    pullRequest.editComment(comment.id, body)
+                    echo 'Submitted comment with test server link.'
+                }
+            }
+        }
+        stage('Build Beta/Prod Images') {
+            steps {
+                script {
+                    if (pullRequest.body.contains('[BETAPROD]')) {
+                      body += '\nBuilding beta/prod images.'
+                      pullRequest.editComment(comment.id, body)
+
+                      sh './docker_build.sh jenkins_${BUILD_ID} betaprod'
+                      
+                      body += '\nBuilt and uploaded images for beta and prod.'
+                      pullRequest.editComment(comment.id, body)
+                    } else {
+                      body += '\nSkipping beta/prod images. Include "[BETAPROD]" in the pull request body to have them built.'
+                      pullRequest.editComment(comment.id, body)
+                    }
+                }
+            }
+        }
+    }
+    post {
+        failure {
+            script {
+                body += '\n\n[Failed build.](http://kismarton.frogtown.me:8079/job/PullRequestBuilds/view/change-requests/job/PR-' + env.CHANGE_ID + '/)';
+                pullRequest.editComment(comment.id, body)
+                echo 'Submitted comment about failed build.'
+            }
+        }
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
         }
         stage('Build') {
             steps {
-                sh 'npm install && npm run-script build && ./docker_build.sh jenkins local'
+                sh 'npm install && npm run-script build && ./docker_build.sh jenkins_${CHANGE_ID}_${BUILD_ID} local'
             }
         }
         stage('Test') {
@@ -58,7 +58,7 @@ pipeline {
                       body += '\nBuilding beta/prod images.'
                       pullRequest.editComment(comment.id, body)
 
-                      sh './docker_build.sh jenkins_${BUILD_ID} betaprod'
+                      sh './docker_build.sh jenkins_${CHANGE_ID}_${BUILD_ID} betaprod'
                       
                       body += '\nBuilt and uploaded images for beta and prod.'
                       pullRequest.editComment(comment.id, body)

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -1,12 +1,30 @@
-echo "Building beta version..."
-cp "config.beta.json" "config.json"
-sudo docker build -t gcr.io/frogtown/frogtown2020/beta .
-sudo docker push gcr.io/frogtown/frogtown2020/beta
+if [ -z "$1" ]
+then
+  echo "Missing argument"
+  exit 1
+fi
 
-echo "Building prod version..."
-cp "config.prod.json" "config.json"
-sudo docker build -t gcr.io/frogtown/frogtown2020/prod .
-sudo docker push gcr.io/frogtown/frogtown2020/prod
+echo "Copying in secrets..."
+cp -r "/home/jenkins/frogtown/secrets" .;
 
-cp "config.local.json" "config.json"
+if [ "$2" != "local" ]
+then
+  echo "Building beta version..."
+  cp "config.beta.json" "config.json" || cp "/home/jenkins/frogtown/config/config.beta.json" "config.json";
+  docker build -t gcr.io/frogtown/frogtown2020/beta:$1 .
+  docker push gcr.io/frogtown/frogtown2020/beta:$1
+
+  echo "Building prod version..."
+  cp "config.prod.json" "config.json" || cp "/home/jenkins/frogtown/config/config.prod.json" "config.json";
+  docker build -t gcr.io/frogtown/frogtown2020/prod:$1 .
+  docker push gcr.io/frogtown/frogtown2020/prod:$1
+fi
+
+if [ "$2" != "betaprod" ]
+then
+  echo "Building local version..."
+  cp "config.local.json" "config.json" || cp "/home/jenkins/frogtown/config/config.local.json" "config.json";
+  docker build -t gcr.io/frogtown/frogtown2020/local:$1 .
+fi
+
 echo "Done building and restored local config."

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "start": "node ./bin/server/runner.js",
     "test": "jest",
     "lint": "npx eslint \"./src/**/*.ts\"",
+    "build": "tsc && npx webpack --config ./bin/webpack.config.js",
     "startprod": "node ./bin/server/runner.js",
     "startupdater": "node ./bin/updater/runner.js",
     "startconverter": "node ./bin/data_converter/runner.js",


### PR DESCRIPTION
Add a Jenkinsfile that automatically builds and deploys test servers for pull requests. By default, only a local build will be created for ease of review, but by including a special string in the comment you can trigger the beta and prod images to be built and uploaded as well. This will prevent us from making mistakes where we accidentally include things in an image that we didn't intend. Also, by building the beta and prod images as a CI step it makes it a little harder to push changes to beta/prod without a PR.

Up to 5 test servers will run at a time, cycling through ports 8543-8548. A link to the test server will be commented on the PR so you don't really need to care which port was selected, but having 5 means the last couple commits in a PR will have valid links that you can go back and look at.