### PR TITLE
Add debug banner that is populated by Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,7 +43,7 @@ pipeline {
                   CONTAINERID=$(docker ps -q --filter publish=$PORT);
                   echo Found existing container: $CONTAINERID;
                   [ -z "$CONTAINERID" ] || docker stop $(docker ps -q --filter publish=$PORT);
-                  BANNER="<a href=https://github.com/ToyDragon/frogtown2020/pull/$CHANGE_ID>PR $CHANGE_ID VERSION $BUILD_ID</a>"
+                  BANNER="<a href='https://github.com/ToyDragon/frogtown2020/pull/$CHANGE_ID'>PR $CHANGE_ID VERSION $BUILD_ID</a>"
                   echo "Banner string: $BANNER"
                   docker run -d -l jenkins -p $PORT:8443 -e FROGTOWN_DEBUG_BANNER="$BANNER" gcr.io/frogtown/frogtown2020/local:jenkins_${CHANGE_ID}_${BUILD_ID};
                 '''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,7 +43,9 @@ pipeline {
                   CONTAINERID=$(docker ps -q --filter publish=$PORT);
                   echo Found existing container: $CONTAINERID;
                   [ -z "$CONTAINERID" ] || docker stop $(docker ps -q --filter publish=$PORT);
-                  docker run -d -l jenkins -p $PORT:8443 gcr.io/frogtown/frogtown2020/local:jenkins;
+                  BANNER="<a href=https://github.com/ToyDragon/frogtown2020/pull/$CHANGE_ID>PR $CHANGE_ID VERSION $BUILD_ID</a>"
+                  echo "Banner string: $BANNER"
+                  docker run -d -l jenkins -p $PORT:8443 -e FROGTOWN_DEBUG_BANNER="$BANNER" gcr.io/frogtown/frogtown2020/local:jenkins;
                 '''
                 script {
                     body += '\nDeployed [test server](https://kismarton.frogtown.me:' + (8543 + ((env.BUILD_ID as Integer) % 5)) + ') for change ' + env.CHANGE_ID + '/' + env.BUILD_ID

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,7 @@ pipeline {
                   [ -z "$CONTAINERID" ] || docker stop $(docker ps -q --filter publish=$PORT);
                   BANNER="<a href=https://github.com/ToyDragon/frogtown2020/pull/$CHANGE_ID>PR $CHANGE_ID VERSION $BUILD_ID</a>"
                   echo "Banner string: $BANNER"
-                  docker run -d -l jenkins -p $PORT:8443 -e FROGTOWN_DEBUG_BANNER="$BANNER" gcr.io/frogtown/frogtown2020/local:jenkins;
+                  docker run -d -l jenkins -p $PORT:8443 -e FROGTOWN_DEBUG_BANNER="$BANNER" gcr.io/frogtown/frogtown2020/local:jenkins_${CHANGE_ID}_${BUILD_ID};
                 '''
                 script {
                     body += '\nDeployed [test server](https://kismarton.frogtown.me:' + (8543 + ((env.BUILD_ID as Integer) % 5)) + ') for change ' + env.CHANGE_ID + '/' + env.BUILD_ID

--- a/src/server/handler_views.ts
+++ b/src/server/handler_views.ts
@@ -115,7 +115,10 @@ const includedDataUserDetails: IncludedData = {
 };
 
 // Creates route handler to serve views
-export default function ViewHandler(services: Services): express.Router {
+export default function ViewHandler(
+  services: Services,
+  debugBanner: string
+): express.Router {
   const router = express.Router();
   const allPages = GetAllPages(services);
   const viewDir = __dirname + "/../views/";
@@ -146,6 +149,7 @@ export default function ViewHandler(services: Services): express.Router {
           view: view,
           allViews: allPages,
           route: view.routes[0],
+          debugBanner: debugBanner,
           includedData: JSON.stringify(includedData),
         });
         perfSession.Pop();

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -100,11 +100,15 @@ export default class Server {
         perfMon: perfMon,
       };
 
+      // Load debug banner variable.
+      const debugBanner = process.env["FROGTOWN_DEBUG_BANNER"] || "";
+      Logs.logInfo(`Displaying debug banner: ${debugBanner}`);
+
       // Handlers
       const imageHandler = ImagesHandler(services);
       app.use(ErrorHandler); // Trigger on unhandled errors
       app.use(SetupRequiredHandler(services));
-      app.use(ViewHandler(services));
+      app.use(ViewHandler(services, debugBanner));
       app.use(WellKnownHandler(services));
       app.use("/CardBack.jpg", express.static("./static/CardBack.jpg"));
       for (const path of config.cardImageRoutes) {

--- a/static/styles/core.css
+++ b/static/styles/core.css
@@ -316,3 +316,14 @@ button[disabled] {
   position: relative;
   top: 2px;
 }
+
+#debugBanner {
+  position: absolute;
+  right: 17px;
+  top: 11px;
+  color: black;
+  font-size: 24px;
+  background-color: pink;
+  padding: 5px;
+  border-radius: 4px;
+}

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -18,4 +18,7 @@
       <% } %>
     <% } %>
   <% } %>
+  <% if (debugBanner) { %>
+    <div id="debugbanner"><%- debugBanner -%></div>
+  <% } %>
 </div>


### PR DESCRIPTION
This will make it easy to identify what commit a server came from, which is necessary because we reuse servers. Soon we'll have links that point to containers that have been repurposed, and this will make it easier to identify that.

