### PR TITLE
Refactor integration tests to use errors

### DIFF
--- a/src/integration_tests/integration_test.ts
+++ b/src/integration_tests/integration_test.ts
@@ -1,6 +1,42 @@
 // eslint-disable-next-line node/no-unpublished-import
 import puppeteer from "puppeteer";
 
+export async function verifyExistsAndGetValue(
+  page: puppeteer.Page,
+  selector: string,
+  property: string
+): Promise<string> {
+  try {
+    return await page.$eval<string>(
+      selector,
+      (e, property) =>
+        ((e as unknown) as Record<string, string>)[property as string],
+      property
+    );
+  } catch (e) {
+    // Throw an error with more meaningful debug info.
+    console.error(e);
+    throw new Error(
+      `Unable to find element "${selector}" while trying to get property "${property}".`
+    );
+  }
+}
+
+export async function assertValueSatisfies(
+  page: puppeteer.Page,
+  selector: string,
+  property: string,
+  condition: (val: string) => boolean
+): Promise<string> {
+  const actualValue = await verifyExistsAndGetValue(page, selector, property);
+  if (!condition(actualValue)) {
+    throw new Error(
+      `Element with selector "${selector}" with value "${actualValue}" did not satisfy condition "${condition}".`
+    );
+  }
+  return actualValue;
+}
+
 export interface RunParams {
   browser: puppeteer.Browser;
   authCookies: puppeteer.Protocol.Network.CookieParam[];
@@ -10,5 +46,5 @@ export interface RunParams {
 
 export abstract class IntegrationTest {
   abstract name(): string;
-  abstract run(params: RunParams): Promise<boolean>;
+  abstract run(params: RunParams): Promise<void>;
 }

--- a/src/integration_tests/runner.ts
+++ b/src/integration_tests/runner.ts
@@ -55,12 +55,14 @@ import SettingsChangeUsernameTest from "./tests/settings_change_username_test";
     new SettingsChangeUsernameTest(),
   ];
   for (const test of tests) {
-    console.log("Running test " + test.name());
-    if (!(await test.run(runParams))) {
+    process.stdout.write("Running test " + test.name() + "... ");
+    try {
+      await test.run(runParams);
+      process.stdout.write("Passed!\n");
+    } catch (e) {
+      process.stdout.write("Failed!\n");
+      console.error(e);
       failed = true;
-      console.log("... Failed");
-    } else {
-      console.log("... Passed!");
     }
   }
   await browser.close();

--- a/src/integration_tests/runner.ts
+++ b/src/integration_tests/runner.ts
@@ -3,6 +3,7 @@ import commandLineArgs from "command-line-args";
 import puppeteer from "puppeteer";
 import { IntegrationTest, RunParams } from "./integration_test";
 import CardsearchLoadsTest from "./tests/cardsearch_loads_test";
+import SettingsChangeUsernameTest from "./tests/settings_change_username_test";
 
 (async () => {
   // Setup command line params
@@ -49,7 +50,10 @@ import CardsearchLoadsTest from "./tests/cardsearch_loads_test";
     port: port,
   };
   let failed = false;
-  const tests: IntegrationTest[] = [new CardsearchLoadsTest()];
+  const tests: IntegrationTest[] = [
+    new CardsearchLoadsTest(),
+    new SettingsChangeUsernameTest(),
+  ];
   for (const test of tests) {
     console.log("Running test " + test.name());
     if (!(await test.run(runParams))) {
@@ -62,7 +66,9 @@ import CardsearchLoadsTest from "./tests/cardsearch_loads_test";
   await browser.close();
 
   if (failed) {
-    throw new Error("Integration tests failed.");
+    console.error("Integration tests failed.");
+    // eslint-disable-next-line no-process-exit
+    process.exit(1);
   } else {
     console.log("All tests passed.");
   }

--- a/src/integration_tests/tests/cardsearch_loads_test.ts
+++ b/src/integration_tests/tests/cardsearch_loads_test.ts
@@ -5,7 +5,7 @@ export default class CardsearchLoadsTest extends IntegrationTest {
     return "CardsearchLoadsTest";
   }
 
-  async run(params: RunParams): Promise<boolean> {
+  async run(params: RunParams): Promise<void> {
     const page = await params.browser.newPage();
     await page.setCookie(...params.authCookies);
     await page.goto(
@@ -16,9 +16,7 @@ export default class CardsearchLoadsTest extends IntegrationTest {
       return (window as any).includedData;
     });
     if (!includedData) {
-      console.log("No includedData on cardsearch.html");
-      return false;
+      throw new Error("No includedData on cardsearch.html");
     }
-    return true;
   }
 }

--- a/src/integration_tests/tests/settings_change_username_test.ts
+++ b/src/integration_tests/tests/settings_change_username_test.ts
@@ -1,0 +1,88 @@
+import { timeout } from "../../shared/utils";
+import { IntegrationTest, RunParams } from "../integration_test";
+
+export default class SettingsChangeUsernameTest extends IntegrationTest {
+  name(): string {
+    return "SettingsChangeUsernameTest";
+  }
+
+  async run(params: RunParams): Promise<boolean> {
+    const page = await params.browser.newPage();
+    await page.setCookie(...params.authCookies);
+    await page.goto(`https://${params.serverUrl}:${params.port}/settings.html`);
+    const testName = "Kanye West " + Math.trunc(Math.random() * 100000);
+
+    // Verify that the checkmark is visible.
+    let okClass = await page.$eval<string>(
+      "#inputName + .refresh + .ok",
+      (e) => e.className
+    );
+    if (!okClass) {
+      console.log("No checkmark icon element.");
+      return false;
+    }
+    if (okClass.indexOf("nodisp") >= 0) {
+      console.log("Checkmark hidden initially.");
+      return false;
+    }
+
+    // Change the name in the input.
+    await page.type("#inputName", testName, {
+      delay: 25,
+    });
+    // Force the input to have the correct value, because puppeteer can't type correctly.
+    // We still need to call page.type to trigger the keyboard events.
+    await page.evaluate((testName) => {
+      (document.querySelector(
+        "#inputName"
+      ) as HTMLInputElement).value = testName;
+    }, testName);
+
+    // Verify that the checkmark has disappeared while the change is pending.
+    okClass = await page.$eval<string>(
+      "#inputName + .refresh + .ok",
+      (e) => e.className
+    );
+    if (!okClass) {
+      console.log("No checkmark icon element.");
+      return false;
+    }
+    if (okClass.indexOf("nodisp") === -1) {
+      console.log("Checkmark not hidden while change pending.");
+      return false;
+    }
+
+    // Verify that the checkmark is back after some time.
+    await timeout(1500);
+    okClass = await page.$eval<string>(
+      "#inputName + .refresh + .ok",
+      (e) => e.className
+    );
+    if (!okClass) {
+      console.log("No checkmark icon element.");
+      return false;
+    }
+    if (okClass.indexOf("nodisp") >= 0) {
+      console.log("Checkmark hidden after change should have submitted.");
+      return false;
+    }
+
+    // Verify that the name change persists after reloading the page.
+    await page.reload();
+    await page.waitForTimeout(250);
+    const inputValue = await page.$eval<string>(
+      "#inputName",
+      (e) => (e as HTMLInputElement).value
+    );
+    if (!inputValue) {
+      console.log("No name input element.");
+      return false;
+    }
+    if (inputValue !== testName) {
+      console.log("Name input doesn't have test name after reload.");
+      return false;
+    }
+
+    return true;
+  }
+}


### PR DESCRIPTION
Using errors for failure allows us to have much shorter assertions that call helpers, which can then throw the errors.