### PR TITLE
Duplicates bug two

### DIFF
--- a/src/integration_tests/tests/deck_editor/verify_deck_editor_grid_actions.ts
+++ b/src/integration_tests/tests/deck_editor/verify_deck_editor_grid_actions.ts
@@ -45,10 +45,12 @@ export default async function verifyDeckEditorGridActions(
   );
 
   // Test similar.
-  // TODO: After fixing the bug, select some filters here to verify they are deselected.
-  await click(page, "#filterSelection > div > ul > text");
-  await click(page, "#filterSelection > div > ul > rarity");
-  await click(page, "#filterSelection > div > ul > set");
+  await click(page, "#filterSelection button");
+  await click(page, "#filterSelection > div > ul > li[data-filtertype=text]");
+  await click(page, "#filterSelection button");
+  await click(page, "#filterSelection > div > ul > li[data-filtertype=rarity]");
+  await click(page, "#filterSelection button");
+  await click(page, "#filterSelection > div > ul > li[data-filtertype=set]");
   await page.hover(
     `#mainboard .cardContainer > div[data-id='${deck.mainboard[0].id}']`
   );

--- a/src/integration_tests/tests/deck_editor/verify_deck_editor_grid_actions.ts
+++ b/src/integration_tests/tests/deck_editor/verify_deck_editor_grid_actions.ts
@@ -46,6 +46,9 @@ export default async function verifyDeckEditorGridActions(
 
   // Test similar.
   // TODO: After fixing the bug, select some filters here to verify they are deselected.
+  await click(page, "#filterSelection > div > ul > text");
+  await click(page, "#filterSelection > div > ul > rarity");
+  await click(page, "#filterSelection > div > ul > set");
   await page.hover(
     `#mainboard .cardContainer > div[data-id='${deck.mainboard[0].id}']`
   );

--- a/src/views/cardsearch/behavior.tsx
+++ b/src/views/cardsearch/behavior.tsx
@@ -78,7 +78,11 @@ class CardSearchViewBehavior extends ViewBehavior<unknown> {
       // Intentionally blank
     } else if (action === "similar") {
       console.log("looking for similar cards");
-      $("#filterSelection > div > ul > li[data-active=true]").trigger("click");
+      (document.querySelectorAll(
+        "#filterSelection > div > ul > li[data-active=true]"
+      ) as NodeListOf<HTMLElement> | null)?.forEach((element) => {
+        element.click();
+      });
       $("#filterSelection > div > ul > li[data-filtertype=misc]").trigger(
         "click"
       );

--- a/src/views/deckviewer/behavior.tsx
+++ b/src/views/deckviewer/behavior.tsx
@@ -296,9 +296,11 @@ class DeckViewerViewBehavior extends ViewBehavior<DeckViewerIncludedData> {
       this.saveDeckChange();
     } else if (action === "similar") {
       console.log("looking for similar cards");
-      (document.querySelector(
+      (document.querySelectorAll(
         "#filterSelection > div > ul > li[data-active=true]"
-      ) as HTMLElement | null)?.click();
+      ) as NodeListOf<HTMLElement> | null)?.forEach((element) => {
+        element.click();
+      });
       (document.querySelector(
         "#filterSelection > div > ul > li[data-filtertype=misc]"
       ) as HTMLElement | null)?.click();


### PR DESCRIPTION
All filters now cleared properly when 'show similar' has been selected. It wasn't working as intended.
C'mon Matt.